### PR TITLE
Add phoenix liveview websocket path

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,6 +26,13 @@ server {
     proxy_set_header Connection "Upgrade";
   }
 
+  location /live/websocket {
+    proxy_pass http://api;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+  }
+
   location /api {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This is used for the phoenix live dashboard (see https://github.com/retro-tool/retro-tool-api/blob/master/lib/xrt_web/endpoint.ex#L9).